### PR TITLE
Fix Issue #10: Enable Docker volume persistence for session files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -182,6 +182,8 @@ anon_new.session
 anon_new.session-journal
 *.session.sql
 *.session.sql-journal
+telegram_sessions/
+sessions/
 
 # Claude Desktop config
 claude_desktop_config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -42,5 +42,8 @@ ENV TELEGRAM_SESSION_STRING=""
 # Expose any ports if the application were a web server (not needed for stdio MCP)
 # EXPOSE 8000
 
+# Create a volume for session persistence
+VOLUME ["/app/sessions"]
+
 # Define the command to run the application
 CMD ["python", "main.py"] 

--- a/README.md
+++ b/README.md
@@ -216,8 +216,31 @@ docker run -it --rm \
   telegram-mcp:latest
 ```
 *   Replace placeholders with your actual credentials.
-*   Use `-e TELEGRAM_SESSION_NAME=your_session_file_name` instead of `TELEGRAM_SESSION_STRING` if you prefer file-based sessions (requires volume mounting, see `docker-compose.yml` for an example).
+*   Use `-e TELEGRAM_SESSION_NAME=your_session_file_name` instead of `TELEGRAM_SESSION_STRING` if you prefer file-based sessions (requires volume mounting, see below).
 *   The `-it` flags are crucial for interacting with the server.
+
+**Session Persistence with Docker:**
+
+When using file-based sessions (not `TELEGRAM_SESSION_STRING`), you'll want to persist the session file between container restarts:
+
+1. **Using Docker Compose (Recommended):**
+   The `docker-compose.yml` file already includes volume mounting:
+   ```yaml
+   volumes:
+     - ./telegram_sessions:/app/sessions
+   ```
+   This will create a `telegram_sessions` directory in your project folder to store session files.
+
+2. **Using Docker Run:**
+   Add volume mounting to your docker run command:
+   ```bash
+   docker run -it --rm \
+     -v ./telegram_sessions:/app/sessions \
+     -e TELEGRAM_API_ID="YOUR_API_ID" \
+     -e TELEGRAM_API_HASH="YOUR_API_HASH" \
+     -e TELEGRAM_SESSION_NAME="my_session" \
+     telegram-mcp:latest
+   ```
 
 ---
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,9 +12,8 @@ services:
     # Keep stdin open and allocate a pseudo-TTY, crucial for stdio MCP servers
     stdin_open: true
     tty: true
-    # Optional: Uncomment the following lines to mount a local directory
-    # for persisting the Telegram session file if NOT using TELEGRAM_SESSION_STRING.
-    # Replace './telegram_sessions' with your desired host path.
-    # volumes:
-    #   - ./telegram_sessions:/app
+    # Mount a local directory for persisting the Telegram session file
+    # This is only needed if NOT using TELEGRAM_SESSION_STRING
+    volumes:
+      - ./telegram_sessions:/app/sessions
     restart: unless-stopped 

--- a/main.py
+++ b/main.py
@@ -53,8 +53,14 @@ if SESSION_STRING:
     # Use the string session if available
     client = TelegramClient(StringSession(SESSION_STRING), TELEGRAM_API_ID, TELEGRAM_API_HASH)
 else:
-    # Use file-based session
-    client = TelegramClient(TELEGRAM_SESSION_NAME, TELEGRAM_API_ID, TELEGRAM_API_HASH)
+    # Use file-based session with proper directory
+    # Create sessions directory if it doesn't exist
+    session_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "sessions")
+    os.makedirs(session_dir, exist_ok=True)
+
+    # Use the session name with the sessions directory
+    session_path = os.path.join(session_dir, TELEGRAM_SESSION_NAME)
+    client = TelegramClient(session_path, TELEGRAM_API_ID, TELEGRAM_API_HASH)
 
 # Setup robust logging with both file and console output
 logger = logging.getLogger("telegram_mcp")
@@ -183,10 +189,10 @@ def format_message(message) -> dict[str, Any]:
 
 def get_sender_name(message: Any) -> str:
     """Helper function to get sender name from a message.
-    
+
     Args:
         message: A Telethon Message object.
-        
+
     Returns:
         The sender's name as a string, or "Unknown" if not available.
     """


### PR DESCRIPTION
## Summary
This PR addresses [Issue #10](https://github.com/chigwell/telegram-mcp/issues/10) by implementing proper Docker volume persistence for Telegram session files.

## Changes
- Added `VOLUME` directive to Dockerfile for `/app/sessions` directory
- Enabled volume mounting in `docker-compose.yml` (was previously commented out)
- Updated `main.py` to store file-based sessions in the `sessions` directory
- Added comprehensive documentation to README about Docker session persistence
- Updated `.gitignore` to exclude `telegram_sessions/` and `sessions/` directories

## Technical Details
- Session files are now stored in `/app/sessions` inside the container
- The `docker-compose.yml` mounts `./telegram_sessions` on the host to `/app/sessions` in the container
- This ensures session files persist between container restarts
- Users can still use `TELEGRAM_SESSION_STRING` for string-based sessions (no file persistence needed)

## Testing
- Build and run with Docker Compose
- Authenticate with Telegram using file-based session
- Stop and restart container
- Verify session persists and no re-authentication is needed

## Documentation
Added clear instructions for both Docker Compose and `docker run` users on how to enable session persistence.

Fixes #10

🤖 Generated with [Claude Code](https://claude.ai/code)